### PR TITLE
Add various tooling for room reviews

### DIFF
--- a/src/client/modules/main/pages/pageRoom/PageRoom.js
+++ b/src/client/modules/main/pages/pageRoom/PageRoom.js
@@ -18,6 +18,7 @@ class PageRoom {
 			'dialogEditNote',
 			'charPages',
 			'toaster',
+			'api',
 		], this._init.bind(this));
 	}
 
@@ -30,7 +31,7 @@ class PageRoom {
 			eventBus: this.app.eventBus,
 		});
 		this.module.roomPages.setDefaultPageFactory((ctrl, room, state, layout) => ({
-			component: new PageRoomComponent(this.module, ctrl, room, state, layout),
+			component: new PageRoomComponent(this.app, this.module, ctrl, room, state, layout),
 		}));
 	}
 

--- a/src/client/modules/main/pages/pageRoom/PageRoomExitReview.js
+++ b/src/client/modules/main/pages/pageRoom/PageRoomExitReview.js
@@ -1,0 +1,58 @@
+import { ModelComponent } from 'modapp-resource-component';
+import FormatTxt from 'components/FormatTxt';
+import { Model } from 'modapp-resource';
+
+class PageRoomExitReview {
+	constructor(app, module, ctrl, room, exit) {
+		this.app = app;
+		this.module = module;
+		this.ctrl = ctrl;
+		this.room = room;
+		this.exit = exit;
+	}
+
+	render(el) {
+		const exitId = this.exit.id;
+		const model = new Model({ data: { exit: null, error: null }, eventBus: this.app.eventBus });
+		this.module.api.get('core.exit.' + exitId + '.details')
+			.then(exit => {
+				model.set({ exit });
+			})
+			.catch(error => {
+				model.set({ error });
+			});
+
+		this.elem = new ModelComponent(
+			model,
+			new FormatTxt(`**${this.exit.name}**\n...`, {
+				contentEditable: true,
+			}),
+			(m, c) => {
+				if (m.exit) {
+					c.setFormatText(`**${this.exit.name}**\n` + 
+					`Alice ${m.exit?.leaveMsg}\n` +
+					`Bob ${m.exit?.arriveMsg}\n` +
+					`Eve ${m.exit?.travelMsg}\n`);
+				} else {
+					c.setFormatText(`**${this.exit.name}**`);
+				}
+			},
+		);
+		return this.elem.render(el);
+	}
+
+	unrender() {
+		if (this.elem) {
+			this.elem.unrender();
+			this.elem = null;
+		}
+	}
+
+	_useExit() {
+		this.ctrl.call('useExit', { exitId: this.exit.id })
+			.catch(err => this.module.toaster.openError(err));
+	}
+
+}
+
+export default PageRoomExitReview;

--- a/src/common/components/FormatTxt.js
+++ b/src/common/components/FormatTxt.js
@@ -35,6 +35,7 @@ class FormatTxt extends Fader {
 		this.noInteraction = !!opt.noInteraction;
 		this.setStr = null;
 		this.setFormatText(str);
+		this.contentEditable = opt.contentEditable || false;
 	}
 
 	getState() {
@@ -48,6 +49,11 @@ class FormatTxt extends Fader {
 
 		let div = toComponent(document.createElement('div'));
 		div.className = 'common--formattext';
+
+		// allow the PWA/grammarly plugins to trigger on the div but don't allow
+		// editing as that will screw up the formatting
+		div.contentEditable = this.contentEditable == true;
+		div.onkeydown = (event) => event.metaKey;
 
 		let offset = 0;
 		let sectionRegex = /^\[\[(.*?)\]\](?:\s*\{([\s\S]*?)\} *$| *$)/gm;


### PR DESCRIPTION
This adds support for viewing the exit messages on the same page. It also `contentEditable` on the description so that grammary & prowritingaid would detect it as a text input and overlay the grammar info (the text is still acting read-only).

There are minor issues with CSS, but at this point I'm too deep into the api stack and I got lost track of how it all supposed to work so I'd appreciate some advice. It's also not clear if the model in `PageRoomExitReview` should be disposed of somehow.