### PR TITLE
GH-48: Fixed broken tag tooltips in Dialog windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ npm run client:realm:test
 ```
 
 Open a browser and go to the URL below, but replace `<USER>` and `<PASS>` with the
+[URL encoded](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent)
 username and password of your Mucklet developer account:
 ```text
 http://localhost:6450/?login.player=<USER>&login.pass=<PASS>

--- a/src/common/classes/Dialog.js
+++ b/src/common/classes/Dialog.js
@@ -51,8 +51,10 @@ class Dialog {
 					]),
 					n.component(new Txt(typeof this.opt.title == 'function' ? this.opt.title(this) : this.opt.title, { tagName: 'h2' })),
 				]),
-				n.elem('div', { className: 'dialog--content' }, [
-					n.component(this.content),
+				n.elem('div', { className: 'dialog--content-wrap' }, [
+					n.elem('div', { className: 'dialog--content' }, [
+						n.component(this.content),
+					]),
 				]),
 			]),
 		]));

--- a/src/common/classes/dialog.scss
+++ b/src/common/classes/dialog.scss
@@ -46,10 +46,14 @@
 	border-bottom: 1px solid $color2;
 }
 
-.dialog--content {
+.dialog--content-wrap {
 	flex: 0 1 auto;
 	padding: 16px;
 	overflow-y: auto;
+}
+
+.dialog--content {
+	position: relative;
 }
 
 .dialog--close {

--- a/src/common/components/charTagsList.scss
+++ b/src/common/components/charTagsList.scss
@@ -2,7 +2,6 @@
 @import '~scss/mixins';
 
 .chartagslist {
-	overflow: hidden;
 
 	&--list {
 		margin: -2px;


### PR DESCRIPTION
Minor update to README.md about url encoding the query parameters.