### PR TITLE
Hiding muted events in exported logs behind a hoverable pill

### DIFF
--- a/src/client/modules/main/addons/exportLog/ExportLog.js
+++ b/src/client/modules/main/addons/exportLog/ExportLog.js
@@ -166,7 +166,7 @@ class ExportLog {
 						if (v) {
 							let ec = ev.char;
 							a.push(
-								'<div class="ev ev-' + ev.type + '"' + (ec
+								'<div class="ev ev-' + ev.type + (ev.mod?.muted ? " charlog--muted" : "") + '"' + (ec
 									? ' title="' + escapeHtml((ec.name + " " + ec.surname).trim()) + (ev.time ? "&#013;" + escapeHtml(formatDateTime(new Date(ev.time))) : '') + '"'
 									: ev.time
 										? ' title="' + escapeHtml(formatDateTime(new Date(ev.time))) + '"'

--- a/src/client/modules/main/addons/exportLog/htmlTemplate.js
+++ b/src/client/modules/main/addons/exportLog/htmlTemplate.js
@@ -33,6 +33,28 @@ body { font-family: "Open Sans", sans-serif; font-size: 16px; color: #7d818c; ba
 .charlog--pad-small { margin: 0; padding: 4px 0 2px 0; }
 .charlog--pad { margin: 0; padding: 6px 0 3px 0; }
 .charlog--pad-large { margin: 0; padding: 12px 0 6px 0; }
+.charlog--muted {
+	display: inline-block;
+	box-sizing: border-box;
+	width: 20px;
+	height: 8px;
+	padding: 0 !important;
+	margin: 3px;
+	border-radius: 3px;
+	border: solid 4px #93969f;
+}
+.charlog--muted > div {
+	display: none;
+	position: absolute;
+	width: 100%;
+	padding: 14px;
+	background: rgba(3,4,6,90%);
+	transform: translateY(-100%) translateY(-8px);
+	border-radius: 4px;
+	left: -4px;
+	z-index: 1;
+}
+.charlog--muted:hover > div { display: inline-block; }
 .common--formattext span.ooc { color: #565961; }
 .common--formattext span.cmd { font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace; color: #c1a657; }
 .common--formattext a { color: #4a9fc3; transition: color 0.2s; text-decoration: none; }


### PR DESCRIPTION
This PR is a proposed implementation to resolve #5.

Rather than adding additional steps to the export process (i.e. a toggle option to hide muted events), I've written an implementation that provides a similar experience to what users expect when using the in-game chat history. Stacked pills appear in place of muted events, and the reader can hover over them to see the hidden message.

As Accipiter wished to avoid adding JS to the exported log file, I've only used `.charlog--muted` and `:hover` to accomplish this. The initial commit for this PR is functional, but I suspect it isn't quite up to par with regard to presentation.

![image](https://user-images.githubusercontent.com/20689511/213268246-a3c6d6be-34e2-47df-94df-57cb6832f988.png)

Notably, this PR does not include a solution for click-toggling the popup; this would require something like the [checkbox hack](https://css-tricks.com/the-checkbox-hack/), which may not be desirable. Copy-pasting the text from one of these popups is thus an arcane process that is not ideal.

In order to make the presentation one-to-one with the in-game chat history, further adjustments would need to be made to the `exportHtml` method. For instance, the timestamp appears when hovering over the pill, not the popup; and there is no dialogue triangle connecting the popup directly to the pill it originates from.

For these reasons, I'm marking this as a draft PR.