### PR TITLE
GH-99: Set max-width to 100% to ensure wrapping of section titles.

### DIFF
--- a/src/common/components/formatTxt.scss
+++ b/src/common/components/formatTxt.scss
@@ -13,6 +13,7 @@
 				font-weight: 700;
 			}
 			.panelsection--caret {
+				bottom: 6px;
 				color: $color4-light;
 			}
 		}

--- a/src/common/components/panelSection.scss
+++ b/src/common/components/panelSection.scss
@@ -15,6 +15,8 @@
 
 	&--title {
 		flex: 0 0 auto;
+		padding-right: 10px;
+		max-width: 100%;
 	}
 
 	&--required {


### PR DESCRIPTION
Fixed section caret position when used with FormatTxt.