### PR TITLE
Implement commands to mute ooc messages and messages sent by other characters

### DIFF
--- a/src/client/modules/main/addons/mute/Mute.js
+++ b/src/client/modules/main/addons/mute/Mute.js
@@ -19,6 +19,7 @@ const unmutableEvents = {
 };
 
 const oocEventType = 'ooc';
+const messageEventType = 'message';
 
 /**
  * Mute handles muting of events.
@@ -36,6 +37,7 @@ class Mute {
 		this.muteTravel = new Model({ eventBus: this.app.eventBus });
 		this.muteChars = new Model({ eventBus: this.app.eventBus });
 		this.muteOoc = new Model({ eventBus: this.app.eventBus });
+		this.muteMessage = new Model({ eventBus: this.app.eventBus });
 
 		this.module.charLog.addEventModifier({
 			id: 'mute',
@@ -47,6 +49,7 @@ class Mute {
 		this._loadMute('.travel', this.muteTravel);
 		this._loadMute('.chars', this.muteChars);
 		this._loadMute('.ooc', this.muteOoc);
+		this._loadMute('.message', this.muteMessage);
 	}
 
 	toggleMuteTravel(ctrlId, muteTravel) {
@@ -78,6 +81,17 @@ class Mute {
 
 		return this.muteOoc.set({ [ctrlId]: muteOoc || undefined }).then(() => {
 			this._saveMute('.ooc', this.muteOoc);
+			return true;
+		});
+	}
+
+	toggleMuteMessage(ctrlId, muteMessage) {
+		muteMessage = typeof muteMessage == 'undefined' ? !this.muteMessage.props[ctrlId] : !!muteMessage;
+		let v = this.muteMessage.props.hasOwnProperty(ctrlId);
+		if (muteMessage == v) return Promise.resolve(false);
+
+		return this.muteMessage.set({ [ctrlId]: muteMessage || undefined }).then(() => {
+			this._saveMute('.message', this.muteMessage);
 			return true;
 		});
 	}
@@ -120,6 +134,10 @@ class Mute {
 		}
 
 		if (charId != ctrl.id && this.muteOoc.props[ctrl.id] && (ev.ooc || ev.type === oocEventType)) {
+			muted = true;
+		}
+
+		if (charId != ctrl.id && this.muteMessage.props[ctrl.id] && ev.type === messageEventType) {
 			muted = true;
 		}
 

--- a/src/client/modules/main/addons/mute/Mute.js
+++ b/src/client/modules/main/addons/mute/Mute.js
@@ -44,9 +44,9 @@ class Mute {
 		});
 
 		// Load muted
-		this._loadMuteTravel();
-		this._loadMuteChars();
-		this._loadMuteOoc();
+		this._loadMute('.travel', this.muteTravel);
+		this._loadMute('.chars', this.muteChars);
+		this._loadMute('.ooc', this.muteOoc);
 	}
 
 	toggleMuteTravel(ctrlId, muteTravel) {
@@ -55,7 +55,7 @@ class Mute {
 		if (muteTravel == v) return Promise.resolve(false);
 
 		return this.muteTravel.set({ [ctrlId]: muteTravel || undefined }).then(() => {
-			this._saveMuteTravel();
+			this._saveMute('.travel', this.muteTravel);
 			return true;
 		});
 	}
@@ -66,7 +66,7 @@ class Mute {
 		if (muteChar == v) return Promise.resolve(false);
 
 		return this.muteChars.set({ [charId]: muteChar || undefined }).then(() => {
-			this._saveMuteChars();
+			this._saveMuteChars('.chars', this.muteChars);
 			return true;
 		});
 	}
@@ -77,7 +77,7 @@ class Mute {
 		if (muteOoc == v) return Promise.resolve(false);
 
 		return this.muteOoc.set({ [ctrlId]: muteOoc || undefined }).then(() => {
-			this._saveMuteOoc();
+			this._saveMute('.ooc', this.muteOoc);
 			return true;
 		});
 	}
@@ -91,57 +91,22 @@ class Mute {
 		return !!(charId && this.muteChars.props[charId]);
 	}
 
-	_loadMuteTravel() {
+	_loadMute(type, model) {
 		if (!localStorage) return;
 
 		this.module.auth.getUserPromise().then(user => {
-			let raw = localStorage.getItem(muteStoragePrefix + user.id + '.travel');
+			let raw = localStorage.getItem(muteStoragePrefix + user.id + type);
 			if (raw) {
-				this.muteTravel.reset(JSON.parse(raw));
+				model.reset(JSON.parse(raw));
 			}
 		});
 	}
 
-	_saveMuteTravel() {
-		if (!localStorage) return;
-		this.module.auth.getUserPromise().then(user => {
-			localStorage.setItem(muteStoragePrefix + user.id + '.travel', JSON.stringify(this.muteTravel.props));
-		});
-	}
-
-	_loadMuteOoc() {
+	_saveMute(type, model) {
 		if (!localStorage) return;
 
 		this.module.auth.getUserPromise().then(user => {
-			let raw = localStorage.getItem(muteStoragePrefix + user.id + '.ooc');
-			if (raw) {
-				this.muteOoc.reset(JSON.parse(raw));
-			}
-		});
-	}
-
-	_saveMuteOoc() {
-		if (!localStorage) return;
-		this.module.auth.getUserPromise().then(user => {
-			localStorage.setItem(muteStoragePrefix + user.id + '.ooc', JSON.stringify(this.muteOoc.props));
-		});
-	}
-
-	_loadMuteChars() {
-		if (!localStorage) return;
-
-		this.module.auth.getUserPromise().then(user => {
-			let raw = localStorage.getItem(muteStoragePrefix + user.id + '.chars');
-			if (raw) {
-				this.muteChars.reset(JSON.parse(raw));
-			}
-		});
-	}
-
-	_saveMuteChars() {
-		if (!localStorage) return;
-		this.module.auth.getUserPromise().then(user => {
-			localStorage.setItem(muteStoragePrefix + user.id + '.chars', JSON.stringify(this.muteChars.props));
+			localStorage.setItem(muteStoragePrefix + user.id + type, JSON.stringify(model.props));
 		});
 	}
 

--- a/src/client/modules/main/addons/mute/Mute.js
+++ b/src/client/modules/main/addons/mute/Mute.js
@@ -69,7 +69,7 @@ class Mute {
 		if (muteChar == v) return Promise.resolve(false);
 
 		return this.muteChars.set({ [charId]: muteChar || undefined }).then(() => {
-			this._saveMuteChars('.chars', this.muteChars);
+			this._saveMute('.chars', this.muteChars);
 			return true;
 		});
 	}

--- a/src/client/modules/main/commands/muteMessage/MuteMessage.js
+++ b/src/client/modules/main/commands/muteMessage/MuteMessage.js
@@ -1,0 +1,51 @@
+import l10n from 'modapp-l10n';
+import Err from 'classes/Err';
+
+const usageText = 'mute message';
+const shortDesc = 'Mute messages from other characters';
+const helpText =
+	`<p>Mute messages from other characters. Whispers, poses and say are not affected. It only affects the currently controlled character.</p>
+<p>Use <code>stop mute message</code> to stop muting messages.</p>`;
+
+/**
+ * MuteMessage adds the mute message command.
+ */
+class MuteMessage {
+	constructor(app) {
+		this.app = app;
+
+		this.app.require([ 'muteCmd', 'charLog', 'mute', 'help' ], this._init.bind(this));
+	}
+
+	_init(module) {
+		this.module = module;
+
+		this.module.muteCmd.addType({
+			key: 'message',
+			value: (ctx, p) => this.muteMessage(ctx.char),
+		});
+
+		this.module.help.addTopic({
+			id: 'muteMessage',
+			category: 'mute',
+			cmd: 'mute message',
+			usage: l10n.l('muteMessage.usage', usageText),
+			shortDesc: l10n.l('muteMessage.shortDesc', shortDesc),
+			desc: l10n.l('muteMessage.helpText', helpText),
+			sortOrder: 50,
+		});
+	}
+
+	muteMessage(char) {
+		return this.module.mute.toggleMuteMessage(char.id, true)
+			.then(change => {
+				if (change) {
+					this.module.charLog.logInfo(char, l10n.l('muteMessage.muteMessageStart', "Activated muting of messages."));
+				} else {
+					this.module.charLog.logError(char, new Err('muteMessage.alreadyMutingMessage', "Messages are already getting muted."));
+				}
+			});
+	}
+}
+
+export default MuteMessage;

--- a/src/client/modules/main/commands/muteOoc/MuteOoc.js
+++ b/src/client/modules/main/commands/muteOoc/MuteOoc.js
@@ -1,0 +1,51 @@
+import l10n from 'modapp-l10n';
+import Err from 'classes/Err';
+
+const usageText = 'mute ooc';
+const shortDesc = 'Mute out of character messages';
+const helpText =
+	`<p>Mute out of character messages of other characters. It only affects the currently controlled character.</p>
+<p>Use <code>stop mute ooc</code> to stop muting OOC messages.</p>`;
+
+/**
+ * MuteOoc adds the mute ooc command.
+ */
+class MuteOoc {
+	constructor(app) {
+		this.app = app;
+
+		this.app.require([ 'muteCmd', 'charLog', 'mute', 'help' ], this._init.bind(this));
+	}
+
+	_init(module) {
+		this.module = module;
+
+		this.module.muteCmd.addType({
+			key: 'ooc',
+			value: (ctx, p) => this.muteOoc(ctx.char),
+		});
+
+		this.module.help.addTopic({
+			id: 'muteOoc',
+			category: 'mute',
+			cmd: 'mute ooc',
+			usage: l10n.l('muteOoc.usage', usageText),
+			shortDesc: l10n.l('muteOoc.shortDesc', shortDesc),
+			desc: l10n.l('muteOoc.helpText', helpText),
+			sortOrder: 70,
+		});
+	}
+
+	muteOoc(char) {
+		return this.module.mute.toggleMuteOoc(char.id, true)
+			.then(change => {
+				if (change) {
+					this.module.charLog.logInfo(char, l10n.l('muteOoc.muteOocStart', "Activated muting of OOC messages."));
+				} else {
+					this.module.charLog.logError(char, new Err('muteOoc.alreadyMutingOoc', "OOC messages are already getting muted."));
+				}
+			});
+	}
+}
+
+export default MuteOoc;

--- a/src/client/modules/main/commands/stopMuteChar/StopMuteChar.js
+++ b/src/client/modules/main/commands/stopMuteChar/StopMuteChar.js
@@ -14,10 +14,6 @@ const helpText =
 class StopMuteChar {
 	constructor(app) {
 		this.app = app;
-
-		// Bind callbacks
-		this._exec = this._exec.bind(this);
-
 		this.app.require([ 'cmd', 'stopMute', 'help', 'charLog', 'mute', 'cmdSteps' ], this._init.bind(this));
 	}
 
@@ -45,14 +41,6 @@ class StopMuteChar {
 			desc: l10n.l('stopMuteChar.helpText', helpText),
 			sortOrder: 40,
 		});
-	}
-
-	_exec(ctx, p) {
-		let f = p.object;
-		if (typeof f != 'function') {
-			throw new Error("Object value is not a function");
-		}
-		return f(ctx, p);
 	}
 
 	stopMuteChar(player, char, params) {

--- a/src/client/modules/main/commands/stopMuteMessage/StopMuteMessage.js
+++ b/src/client/modules/main/commands/stopMuteMessage/StopMuteMessage.js
@@ -1,0 +1,63 @@
+import l10n from 'modapp-l10n';
+import Err from 'classes/Err';
+
+const usageText = 'stop mute message';
+const shortDesc = 'Stop muting messages from other characters';
+const helpText =
+`<p>Stop muting messages previously muted with <code>mute message</code>. It only affects the currently controlled character.</p>
+<p>Alias: <code>unmute message</code>`;
+
+/**
+ * StopMuteMessage adds the stop mute message command.
+ */
+class StopMuteMessage {
+	constructor(app) {
+		this.app = app;
+
+		// Bind callbacks
+		this._exec = this._exec.bind(this);
+
+		this.app.require([ 'stopMute', 'help', 'charLog', 'mute' ], this._init.bind(this));
+	}
+
+	_init(module) {
+		this.module = module;
+
+		this.module.stopMute.addType({
+			key: 'message',
+			value: (ctx, p) => this.stopMuteMessage(ctx.char),
+		});
+
+		this.module.help.addTopic({
+			id: 'stopMuteMessage',
+			category: 'mute',
+			cmd: 'stop mute message',
+			alias: [ 'unmute message' ],
+			usage: l10n.l('stopMuteMessage.usage', usageText),
+			shortDesc: l10n.l('stopMuteMessage.shortDesc', shortDesc),
+			desc: l10n.l('stopMuteMessage.helpText', helpText),
+			sortOrder: 60,
+		});
+	}
+
+	_exec(ctx, p) {
+		let f = p.object;
+		if (typeof f != 'function') {
+			throw new Error("Object value is not a function");
+		}
+		return f(ctx, p);
+	}
+
+	stopMuteMessage(char) {
+		return this.module.mute.toggleMuteMessage(char.id, false)
+			.then(change => {
+				if (change) {
+					this.module.charLog.logInfo(char, l10n.l('stopMuteMessage.stopMuteMessage', "Deactivated muting of messages."));
+				} else {
+					this.module.charLog.logError(char, new Err('stopMuteMessage.notMutingMessage', "Messages are not being muted."));
+				}
+			});
+	}
+}
+
+export default StopMuteMessage;

--- a/src/client/modules/main/commands/stopMuteMessage/StopMuteMessage.js
+++ b/src/client/modules/main/commands/stopMuteMessage/StopMuteMessage.js
@@ -13,10 +13,6 @@ const helpText =
 class StopMuteMessage {
 	constructor(app) {
 		this.app = app;
-
-		// Bind callbacks
-		this._exec = this._exec.bind(this);
-
 		this.app.require([ 'stopMute', 'help', 'charLog', 'mute' ], this._init.bind(this));
 	}
 
@@ -38,14 +34,6 @@ class StopMuteMessage {
 			desc: l10n.l('stopMuteMessage.helpText', helpText),
 			sortOrder: 60,
 		});
-	}
-
-	_exec(ctx, p) {
-		let f = p.object;
-		if (typeof f != 'function') {
-			throw new Error("Object value is not a function");
-		}
-		return f(ctx, p);
 	}
 
 	stopMuteMessage(char) {

--- a/src/client/modules/main/commands/stopMuteOoc/StopMuteOoc.js
+++ b/src/client/modules/main/commands/stopMuteOoc/StopMuteOoc.js
@@ -1,0 +1,63 @@
+import l10n from 'modapp-l10n';
+import Err from 'classes/Err';
+
+const usageText = 'stop mute ooc';
+const shortDesc = 'Stop muting out of character messages';
+const helpText =
+`<p>Stop muting out of character messages previously muted with <code>mute ooc</code>. It only affects the currently controlled character.</p>
+<p>Alias: <code>unmute ooc</code>`;
+
+/**
+ * StopMuteOoc adds the stop mute ooc command.
+ */
+class StopMuteOoc {
+	constructor(app) {
+		this.app = app;
+
+		// Bind callbacks
+		this._exec = this._exec.bind(this);
+
+		this.app.require([ 'stopMute', 'help', 'charLog', 'mute' ], this._init.bind(this));
+	}
+
+	_init(module) {
+		this.module = module;
+
+		this.module.stopMute.addType({
+			key: 'ooc',
+			value: (ctx, p) => this.stopMuteOoc(ctx.char),
+		});
+
+		this.module.help.addTopic({
+			id: 'stopMuteOoc',
+			category: 'mute',
+			cmd: 'stop mute ooc',
+			alias: [ 'unmute ooc' ],
+			usage: l10n.l('stopMuteOoc.usage', usageText),
+			shortDesc: l10n.l('stopMuteOoc.shortDesc', shortDesc),
+			desc: l10n.l('stopMuteOoc.helpText', helpText),
+			sortOrder: 80,
+		});
+	}
+
+	_exec(ctx, p) {
+		let f = p.object;
+		if (typeof f != 'function') {
+			throw new Error("Object value is not a function");
+		}
+		return f(ctx, p);
+	}
+
+	stopMuteOoc(char) {
+		return this.module.mute.toggleMuteOoc(char.id, false)
+			.then(change => {
+				if (change) {
+					this.module.charLog.logInfo(char, l10n.l('stopMuteOoc.stopMuteOoc', "Deactivated muting of OOC messages."));
+				} else {
+					this.module.charLog.logError(char, new Err('stopMuteOoc.notMutingOoc', "OOC messages are not being muted."));
+				}
+			});
+	}
+}
+
+export default StopMuteOoc;

--- a/src/client/modules/main/commands/stopMuteOoc/StopMuteOoc.js
+++ b/src/client/modules/main/commands/stopMuteOoc/StopMuteOoc.js
@@ -13,10 +13,6 @@ const helpText =
 class StopMuteOoc {
 	constructor(app) {
 		this.app = app;
-
-		// Bind callbacks
-		this._exec = this._exec.bind(this);
-
 		this.app.require([ 'stopMute', 'help', 'charLog', 'mute' ], this._init.bind(this));
 	}
 
@@ -38,14 +34,6 @@ class StopMuteOoc {
 			desc: l10n.l('stopMuteOoc.helpText', helpText),
 			sortOrder: 80,
 		});
-	}
-
-	_exec(ctx, p) {
-		let f = p.object;
-		if (typeof f != 'function') {
-			throw new Error("Object value is not a function");
-		}
-		return f(ctx, p);
 	}
 
 	stopMuteOoc(char) {

--- a/src/client/modules/main/commands/stopMuteTravel/StopMuteTravel.js
+++ b/src/client/modules/main/commands/stopMuteTravel/StopMuteTravel.js
@@ -13,10 +13,6 @@ const helpText =
 class StopMuteTravel {
 	constructor(app) {
 		this.app = app;
-
-		// Bind callbacks
-		this._exec = this._exec.bind(this);
-
 		this.app.require([ 'stopMute', 'help', 'charLog', 'mute' ], this._init.bind(this));
 	}
 
@@ -38,14 +34,6 @@ class StopMuteTravel {
 			desc: l10n.l('stopMuteTravel.helpText', helpText),
 			sortOrder: 20,
 		});
-	}
-
-	_exec(ctx, p) {
-		let f = p.object;
-		if (typeof f != 'function') {
-			throw new Error("Object value is not a function");
-		}
-		return f(ctx, p);
 	}
 
 	stopMuteTravel(char) {


### PR DESCRIPTION
This PR implements the commands `mute ooc` and `mute message` and the respective `unmute` commands. Both are essentially extensions of the `mute travel` command that already exists.

In addition to the implementation, I took the liberty of doing a tiny bit of cleanup on the localStorage state management in the Mute module, to remove repetitive (internal) code.

As a note, a followup to make the API more consistent would be to add the `.ooc` property to also in-room ooc events, in addition to the current implementation of having it in ooc whispers and messages. This would allow checking just one property to determine whether the event is ooc. (See [this line](https://github.com/mucklet/mucklet-client/pull/235/files#diff-a71635aa301e339c9abbf96295544f0007ddfc636ba17902047edb7568e2a393R136) for context.)