### PR TITLE
GH-87: Implement list focused command

### DIFF
--- a/src/client/modules/main/addons/charFocus/CharFocus.js
+++ b/src/client/modules/main/addons/charFocus/CharFocus.js
@@ -127,7 +127,7 @@ class CharFocus {
 		if (!isValidColor(color)) {
 			color = this.focusColors[char.id] || this._getColor(ctrlId);
 		}
-		
+
 		if (!noUpdate) {
 			this.focusColors[char.id] = color;
 			this._saveFocusColors();
@@ -142,10 +142,19 @@ class CharFocus {
 		return this;
 	}
 
+	/**
+	 * Returns a CharList with the currently focused characters
+	 * @returns	{CharList}	Focused characters of the currently controlled character.
+	 */
 	getFocusCharList() {
 		return this.focusCharList;
 	}
 
+	/**
+	 * Returns an object with focused character ids as keys and their focus colors as values.
+	 * Shared between all controlled characters.
+	 * @returns { [charId: string]: string }	Object containing focus character -> color mapping.
+	 */
 	getFocusCharColors() {
 		return this.focusColors;
 	}

--- a/src/client/modules/main/addons/charFocus/CharFocus.js
+++ b/src/client/modules/main/addons/charFocus/CharFocus.js
@@ -126,7 +126,9 @@ class CharFocus {
 
 		if (!isValidColor(color)) {
 			color = this.focusColors[char.id] || this._getColor(ctrlId);
-		} else if (!noUpdate) {
+		}
+		
+		if (!noUpdate) {
 			this.focusColors[char.id] = color;
 			this._saveFocusColors();
 		}

--- a/src/client/modules/main/addons/charFocus/CharFocus.js
+++ b/src/client/modules/main/addons/charFocus/CharFocus.js
@@ -146,6 +146,10 @@ class CharFocus {
 		return this.focusCharList;
 	}
 
+	getFocusCharColors() {
+		return this.focusColors;
+	}
+
 	/**
 	 * Gets an object with supported focus highlight colors.
 	 * @returns {object} Focus colors where key is the color name and value is


### PR DESCRIPTION
![image](https://github.com/mucklet/mucklet-client/assets/161910439/673d665e-68dc-45c8-b272-2824ce1c37ce)

This PR implements the `list focused` command to fetch the currently focused characters and their colors for the active character.

Fixes #87


It turned out to be somewhat easier than the issue expected, since the actual character model _is_ stored by CharFocus, and loaded again on page reload. After this PR is good, I would like to use the same pattern to implement `list muted` to list ignored characters.