### PR TITLE
Fix handling of deleted characters on focus list and unfocus

### DIFF
--- a/src/client/modules/main/addons/charFocus/CharFocus.js
+++ b/src/client/modules/main/addons/charFocus/CharFocus.js
@@ -90,7 +90,7 @@ class CharFocus {
 			if (!f) return null;
 
 			let list = Object.keys(f).map(k => f[k]);
-			list.sort((a, b) => a.name.localeCompare(b.name) || a.surname.localeCompare(b.surname));
+			list.filter(c => c?.name).sort((a, b) => a.name.localeCompare(b.name) || a.surname.localeCompare(b.surname));
 			return list;
 		});
 		this.style = document.createElement('style');
@@ -198,7 +198,7 @@ class CharFocus {
 			let color = focus[k].color;
 			let char = chars[k];
 			return { char, hex: color, color: isPredefined(color) || color };
-		}).filter(o => o.char);
+		}).filter(o => o.char?.name);
 		list.sort((a, b) => a.char.name.localeCompare(b.char.name) || a.char.surname.localeCompare(b.char.surname));
 		return list;
 	}


### PR DESCRIPTION
I discovered that if there is a deleted/not found character lingering on your focus list, it becomes impossible to use `list focused` and more importantly it is impossible to `unfocus` tab complete because the deleted character crashes the CharList provider.

This is just a minor quick fix to allow the client to work.

For a proper long-term fix, I think these lingering references that might get invalidated by deleted characters should be filtered out of the returned models (`core.char.${charId}.focus.chars` in this case) server-side.