### PR TITLE
Add paths config for Intellisense

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,9 @@
     "noEmit": false,
     "skipLibCheck": true,
     "noImplicitAny": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "paths": {
+      "utils/*": ["./common/utils/*"]
+    }
   },
 }


### PR DESCRIPTION
I noticed while trying to navigate some of the code that the TypeScript engine config included doesn't list the webpack mappings for the common modules (utils etc). This minor improvement to the DX allows the usage of eg Go To Definition with those imports.